### PR TITLE
Fixed quotation of identifiers in yin2yang.xsl.

### DIFF
--- a/models/yin2yang.xsl
+++ b/models/yin2yang.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" 
+<xsl:stylesheet version="1.0"
   xmlns:yin="urn:ietf:params:xml:ns:yang:yin:1"
   xmlns:nacm="urn:ietf:params:xml:ns:yang:ietf-netconf-acm"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -28,25 +28,25 @@
   <xsl:call-template name="indent"><xsl:with-param name="count" select="$pLevel"/></xsl:call-template>
   <xsl:choose>
     <xsl:when test="@name">
-      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@name"/><xsl:text>"</xsl:text>
+      <xsl:value-of select="local-name(.)" /><xsl:text> </xsl:text><xsl:value-of select="@name"/><xsl:text></xsl:text>
     </xsl:when>
     <xsl:when test="@value">
-      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@value"/><xsl:text>"</xsl:text>
+      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@value"/>"<xsl:text></xsl:text>
     </xsl:when>
     <xsl:when test="@date">
-      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@date"/><xsl:text>"</xsl:text>
+      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@date"/>"<xsl:text></xsl:text>
     </xsl:when>
     <xsl:when test="@condition">
-      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@condition"/><xsl:text>"</xsl:text>
+      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@condition"/>"<xsl:text></xsl:text>
     </xsl:when>
     <xsl:when test="@module">
-      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@module"/><xsl:text>"</xsl:text>
+      <xsl:value-of select="local-name(.)" /><xsl:text> </xsl:text><xsl:value-of select="@module"/><xsl:text></xsl:text>
     </xsl:when>
     <xsl:when test="@target-node">
-      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@target-node"/><xsl:text>"</xsl:text>
+      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@target-node"/>"<xsl:text></xsl:text>
     </xsl:when>
     <xsl:when test="@tag">
-      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@tag"/><xsl:text>"</xsl:text>
+      <xsl:value-of select="local-name(.)" /><xsl:text> "</xsl:text><xsl:value-of select="@tag"/>"<xsl:text></xsl:text>
     </xsl:when>
   </xsl:choose>
 

--- a/src/datastore.c
+++ b/src/datastore.c
@@ -1694,6 +1694,12 @@ static char* get_schema(const nc_rpc* rpc, struct nc_err** e)
 				return (NULL);
 			}
 			format = (char*) xmlNodeGetContent(query_result->nodesetval->nodeTab[0]);
+                        char* colon = strrchr(format, ':');
+                        if (colon) {
+                          char* old = format;
+                          format = strdup(colon + 1);
+                          free(old);
+                        }
 		}
 		xmlXPathFreeObject(query_result);
 	}


### PR DESCRIPTION
Stumbled across this one when having a client who hasn't got the latest YANG modules and tries to use get-schema on the server.
All the identifier had quotes around them. 