### PR TITLE
BUGFIX properly handle error-message statements in yin2yang.xsl 

### DIFF
--- a/models/yin2yang.xsl
+++ b/models/yin2yang.xsl
@@ -67,13 +67,22 @@
   </xsl:choose>
 </xsl:template>
 
-<xsl:template match="yin:*[yin:text]" >
+<xsl:template match="yin:*[yin:text]|yin:error-message[yin:value]" >
   <xsl:param name="pLevel"/>
   <xsl:call-template name="indent"><xsl:with-param name="count" select="$pLevel"/></xsl:call-template>
   <xsl:value-of select="local-name(.)" /><xsl:text>
 </xsl:text>
   <xsl:call-template name="indent"><xsl:with-param name="count" select="$pLevel"/></xsl:call-template>
-  <xsl:text>  "</xsl:text><xsl:value-of disable-output-escaping="no" select="yin:text" /><xsl:text>";
+  <xsl:text>  "</xsl:text>
+  <xsl:choose>
+    <xsl:when test="yin:text">
+      <xsl:value-of disable-output-escaping="no" select="yin:text" />
+    </xsl:when>
+    <xsl:when test="yin:value">
+      <xsl:value-of disable-output-escaping="no" select="yin:value" />
+    </xsl:when>
+  </xsl:choose>
+  <xsl:text>";
 </xsl:text>
 </xsl:template>
 


### PR DESCRIPTION
Fixed the XSL template for error-message statements in must statements.
See RFC 6020 section 11.1. for details.