### PR TITLE
BUGFIX Fix netconf-config-change structure

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -1519,7 +1519,7 @@ static int _event_new(time_t etime, NCNTF_EVENT event, va_list params)
 
 		if (asprintf(&content, "<netconf-config-change xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\">"
 				"<datastore>%s</datastore>"
-				"%s</netconf-config-change>",
+				"<changed-by>%s</changed-by></netconf-config-change>",
 				aux1, (aux2 == NULL) ? "" : aux2) == -1) {
 			ERROR("asprintf() failed (%s:%d).", __FILE__, __LINE__);
 			free(aux2);


### PR DESCRIPTION
The information describing the source of the change should be in a container called changed-by, see RFC 6470 Section 2.2.