### PR TITLE
Add eventfd support when accepting a new session using libssh channels

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -136,7 +136,10 @@ struct nc_session* _nc_session_accept(const struct nc_cpblts*, const char*, int,
 
 API struct nc_session *nc_session_accept_libssh_channel(const struct nc_cpblts* capabilities, const char* username, ssh_channel ssh_chan)
 {
-	return (_nc_session_accept(capabilities, username, -1, -1, ssh_chan, NULL));
+	struct nc_session *retval = _nc_session_accept(capabilities, username, -1, -1, ssh_chan, NULL);
+	ssh_session cur_ssh_session = ssh_channel_get_session(ssh_chan);
+	retval->transport_socket = ssh_get_fd(cur_ssh_session);
+	return (retval);
 }
 
 struct nc_session *nc_session_connect_libssh_socket(const char* username, const char* host, int sock, ssh_session ssh_sess)


### PR DESCRIPTION
Found that the nc_session transport_socket was not being set for sessions that are accepted using nc_session_accept_libssh_channel().

Needed so that the file descriptor can be returned from nc_session_get_eventfd().
