### PR TITLE
Fix parallel build -- missing dep of pyapi

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -227,7 +227,7 @@ $(LNCTOOL): $(LNCTOOL).in
 	fi
 
 .PHONY: pyapi
-pyapi: $(PYSRCS)
+pyapi: $(PYSRCS) $(NAME).la
 	@cd python; $(PYTHON) ./setup.py build; cd -;
 
 $(OBJDIR)/%.lo: %.c


### PR DESCRIPTION
Without this change, a parallel build was repeatedly failing on my
machine when invoked with -j4. It seems that the Python module was
attempting to link with -lnetconf which had not been finished yet:

  (...)
  running build
  running build_ext
  building 'netconf' extension
  creating build
  creating build/temp.linux-x86_64-3.4
  x86_64-pc-linux-gnu-gcc -pthread -fPIC -I/usr/include/python3.4m -c netconf.c -o build/temp.linux-x86_64-3.4/netconf.o -Wall -I../src/
  x86_64-pc-linux-gnu-gcc -pthread -fPIC -I/usr/include/python3.4m -c session.c -o build/temp.linux-x86_64-3.4/session.o -Wall -I../src/
  creating build/lib.linux-x86_64-3.4
  x86_64-pc-linux-gnu-gcc -pthread -shared build/temp.linux-x86_64-3.4/netconf.o build/temp.linux-x86_64-3.4/session.o -L/usr/lib64 -lnetconf -lpython3.4m -o build/lib.linux-x86_64-3.4/netconf.cpython-34m.so -L../.libs/
  /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lnetconf