### PR TITLE
Enable debugging of netconf message interchanges

### DIFF
--- a/examples/apps/get.c
+++ b/examples/apps/get.c
@@ -51,7 +51,7 @@
 #endif
 
 #define CAPABILITY_PREFIX "urn:ietf:params:netconf:"
-#define ARGUMENTS "f:hl:p:v"
+#define ARGUMENTS "f:hl:p:vd"
 
 void clb_print(NC_VERB_LEVEL level, const char* msg)
 {
@@ -132,6 +132,10 @@ int main(int argc, char* argv[])
 
 		case 'v': /* Verbose operation */
 			verbose = NC_VERB_VERBOSE;
+			break;
+
+		case 'd':
+			verbose = NC_VERB_DEBUG;
 			break;
 
 		default:


### PR DESCRIPTION
Right now, I have no clue how NETCONF works, so when I see this message:

  NETCONF error: missing-attribute (rpc) - Wrong document: namespaces not specified

I have no clue if my device is funny or misconfigured or if the
libnetconf is to blame. Let's enable debugging to figure this out.