### PR TITLE
Add option to disable installing documentation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -67,6 +67,7 @@ LDCONFIG = ldconfig
 INSTALL = @INSTALL@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
 INSTALL_DATA = @INSTALL_DATA@
+INSTALL_DOC = @INSTALL_DOC@
 RPMDIR = RPMBUILD
 NC_WORKINGDIR_PATH = $(DESTDIR)/@NC_WORKINGDIR_PATH@
 NC_SESSIONFILE_PATH = $(DESTDIR)/@NC_SESSIONFILE_PATH@
@@ -297,7 +298,7 @@ rpm: tarball $(TARBALLPYAPI)
 	fi
 
 .PHONY: install
-install: all install-bin install-devel install-doc $(INSTALLPYAPI)
+install: all install-bin install-devel $(INSTALL_DOC) $(INSTALLPYAPI)
 
 .PHONY: install-bin
 install-bin:

--- a/configure
+++ b/configure
@@ -715,6 +715,7 @@ SSH_PROG
 UNAME
 PYPREFIX
 PYTHON
+INSTALL_DOC
 LIBSSH_DIRECTIVE
 MONITORING_LIST_SIZE
 READ_TIMEOUT
@@ -788,6 +789,7 @@ enable_yang_schemas
 enable_notifications
 enable_url
 enable_validation
+enable_doc
 enable_debug
 enable_debug_threads
 with_workingdir
@@ -1443,6 +1445,7 @@ Optional Features:
   --disable-notifications Disable support of NETCONF Notifications (RFC 5277)
   --disable-url           Disable support of NETCONF URL Capability (RFC 6241)
   --disable-validation    Disable support for configuration data validation
+  --disable-doc           Disable generation of documentation
   --enable-debug          Compile with debug options
   --enable-debug-threads  Extend debug mode for threads
   --enable-shared[=PKGS]  build shared libraries [default=yes]
@@ -3161,6 +3164,28 @@ if test "$validation" = "no"; then
 	CONFIGURE_PARAMS="--disable-validation $CONFIGURE_PARAMS"
 	CPPFLAGS="$CPPFLAGS -DDISABLE_VALIDATION"
 fi
+
+# Check whether --enable-doc was given.
+if test "${enable_doc+set}" = set; then :
+  enableval=$enable_doc;
+        if test "$enableval" = "no"; then
+                doc="no"
+        else
+                doc="yes"
+        fi
+
+else
+  # support doc by default
+        doc="yes"
+
+fi
+
+if test "$doc" = "no"; then
+	INSTALL_DOC=""
+else
+	INSTALL_DOC=install-doc
+fi
+
 
 # Check whether --enable-debug was given.
 if test "${enable_debug+set}" = set; then :
@@ -5287,7 +5312,8 @@ else
     ;;
   *)
     lt_cv_sys_max_cmd_len=`(getconf ARG_MAX) 2> /dev/null`
-    if test -n "$lt_cv_sys_max_cmd_len"; then
+    if test -n "$lt_cv_sys_max_cmd_len" && \
+	test undefined != "$lt_cv_sys_max_cmd_len"; then
       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \/ 4`
       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \* 3`
     else
@@ -5688,10 +5714,6 @@ freebsd* | dragonfly*)
   fi
   ;;
 
-gnu*)
-  lt_cv_deplibs_check_method=pass_all
-  ;;
-
 haiku*)
   lt_cv_deplibs_check_method=pass_all
   ;;
@@ -5730,11 +5752,11 @@ irix5* | irix6* | nonstopux*)
   ;;
 
 # This must be glibc/ELF.
-linux* | k*bsd*-gnu | kopensolaris*-gnu)
+linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   lt_cv_deplibs_check_method=pass_all
   ;;
 
-netbsd*)
+netbsd* | netbsdelf*-gnu)
   if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
     lt_cv_deplibs_check_method='match_pattern /lib[^/]+(\.so\.[0-9]+\.[0-9]+|_pic\.a)$'
   else
@@ -6870,12 +6892,19 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
 	    LD="${LD-ld} -m elf_i386_fbsd"
 	    ;;
 	  x86_64-*linux*)
-	    LD="${LD-ld} -m elf_i386"
+	    case `/usr/bin/file conftest.o` in
+	      *x86-64*)
+		LD="${LD-ld} -m elf32_x86_64"
+		;;
+	      *)
+		LD="${LD-ld} -m elf_i386"
+		;;
+	    esac
 	    ;;
-	  powerpc64le-*linux*)
+	  powerpc64le-*)
 	    LD="${LD-ld} -m elf32lppclinux"
 	    ;;
-	  powerpc64-*linux*)
+	  powerpc64-*)
 	    LD="${LD-ld} -m elf32ppclinux"
 	    ;;
 	  s390x-*linux*)
@@ -6894,10 +6923,10 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
 	  x86_64-*linux*)
 	    LD="${LD-ld} -m elf_x86_64"
 	    ;;
-	  powerpcle-*linux*)
+	  powerpcle-*)
 	    LD="${LD-ld} -m elf64lppc"
 	    ;;
-	  powerpc-*linux*)
+	  powerpc-*)
 	    LD="${LD-ld} -m elf64ppc"
 	    ;;
 	  s390*-*linux*|s390*-*tpf*)
@@ -8564,7 +8593,7 @@ lt_prog_compiler_static=
       lt_prog_compiler_static='-non_shared'
       ;;
 
-    linux* | k*bsd*-gnu | kopensolaris*-gnu)
+    linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
       case $cc_basename in
       # old Intel for x86_64 which still supported -KPIC.
       ecc*)
@@ -9042,6 +9071,9 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
   openbsd*)
     with_gnu_ld=no
     ;;
+  linux* | k*bsd*-gnu | gnu*)
+    link_all_deplibs=no
+    ;;
   esac
 
   ld_shlibs=yes
@@ -9263,7 +9295,7 @@ _LT_EOF
       fi
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	archive_cmds='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
 	wlarc=
@@ -9440,6 +9472,7 @@ _LT_EOF
 	if test "$aix_use_runtimelinking" = yes; then
 	  shared_flag="$shared_flag "'${wl}-G'
 	fi
+	link_all_deplibs=no
       else
 	# not using gcc
 	if test "$host_cpu" = ia64; then
@@ -9893,7 +9926,7 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
       link_all_deplibs=yes
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	archive_cmds='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
       else
@@ -10730,17 +10763,6 @@ freebsd* | dragonfly*)
   esac
   ;;
 
-gnu*)
-  version_type=linux # correct to gnu/linux during the next big refactor
-  need_lib_prefix=no
-  need_version=no
-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
-  soname_spec='${libname}${release}${shared_ext}$major'
-  shlibpath_var=LD_LIBRARY_PATH
-  shlibpath_overrides_runpath=no
-  hardcode_into_libs=yes
-  ;;
-
 haiku*)
   version_type=linux # correct to gnu/linux during the next big refactor
   need_lib_prefix=no
@@ -10857,7 +10879,7 @@ linux*oldld* | linux*aout* | linux*coff*)
   ;;
 
 # This must be glibc/ELF.
-linux* | k*bsd*-gnu | kopensolaris*-gnu)
+linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   version_type=linux # correct to gnu/linux during the next big refactor
   need_lib_prefix=no
   need_version=no
@@ -10919,6 +10941,18 @@ fi
   # people can always --disable-shared, the test was removed, and we
   # assume the GNU/Linux dynamic linker is in use.
   dynamic_linker='GNU/Linux ld.so'
+  ;;
+
+netbsdelf*-gnu)
+  version_type=linux
+  need_lib_prefix=no
+  need_version=no
+  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+  soname_spec='${libname}${release}${shared_ext}$major'
+  shlibpath_var=LD_LIBRARY_PATH
+  shlibpath_overrides_runpath=no
+  hardcode_into_libs=yes
+  dynamic_linker='NetBSD ld.elf_so'
   ;;
 
 netbsd*)

--- a/configure.in
+++ b/configure.in
@@ -266,6 +266,25 @@ if test "$validation" = "no"; then
 	CPPFLAGS="$CPPFLAGS -DDISABLE_VALIDATION"
 fi
 
+AC_ARG_ENABLE([doc],
+        AC_HELP_STRING([--disable-doc], [Disable generation of documentation]),
+        [
+        if test "$enableval" = "no"; then
+                doc="no"
+        else
+                doc="yes"
+        fi
+        ],
+        # support doc by default
+        doc="yes"
+)
+if test "$doc" = "no"; then
+	INSTALL_DOC=""
+else
+	INSTALL_DOC=install-doc
+fi
+AC_SUBST(INSTALL_DOC)
+
 AC_ARG_ENABLE([debug],
 	AC_HELP_STRING([--enable-debug],[Compile with debug options]),
 	CFLAGS="$CFLAGS -g -O0 -DDEBUG"


### PR DESCRIPTION
Added --disable-doc configure argument to disable installing documentation.
Documentation is still installed by default