### PR TITLE
Corrected get-schema: was returning extra <data> nodes.

### DIFF
--- a/src/messages.c
+++ b/src/messages.c
@@ -1578,7 +1578,8 @@ API char* nc_reply_get_data(const nc_reply* reply)
 			}
 
 			if (aux_data) {
-				if (xmlStrcmp(aux_data->ns->href, BAD_CAST NC_NS_BASE10) == 0) {
+				if ((xmlStrcmp(aux_data->ns->href, BAD_CAST NC_NS_BASE10) == 0) ||
+					(xmlStrcmp(aux_data->ns->href, BAD_CAST NC_NS_MONITORING) == 0)) {
 					aux_data_custom = NULL;
 					data = xmlCopyNode(aux_data, 1);
 				}


### PR DESCRIPTION
Hi, 
during the weekend regression test we found out that the latest pull request related to user-defined rpcs and custom rpc-replies is broken for get-schema requests:


```
netconf> get-schema

  Set identifier of the schema to retrieve: ne

  Result:
<data xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring">
    <data>
      <data/>
      <data/>
    </data>
    <data>
      <data>
        <data>
          <data>
            <data>
              <data>
                <data>
                  <data>
                    <data>
                      <data>module "ne" {
  namespace "urn:some:toaster";
  prefix "toaster";
...
...

```

the check for real \<data\> node also needs to take into account the netconf state monitoring namespace. 

thanks and best regards
joao