### PR TITLE
do not break fmon loop on EINTR error

### DIFF
--- a/src/datastore.c
+++ b/src/datastore.c
@@ -773,6 +773,8 @@ static void* transapi_fmon(void *arg)
 			ERROR("Inotify failed (EOF).");
 			break;
 		} else if (r == -1) {
+			if(errno == EINTR)
+		            continue;
 			ERROR("Inotify failed (%s).", strerror(errno));
 			break;
 		}


### PR DESCRIPTION
read can be interrupted by a signal but it is not error indeed and file
monitoring can be continued