### PR TITLE
Fix memory leaks in a few error branches, found by cppcheck.

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -167,11 +167,13 @@ static char* callback_sshauth_password_default (const char* username,
 
 	if ((tty = fopen("/dev/tty", "r+")) == NULL) {
 		ERROR("Unable to open the current terminal (%s:%d - %s).", __FILE__, __LINE__, strerror(errno));
+		free(buf);
 		return (NULL);
 	}
 
 	if (tcgetattr(fileno(tty), &oldterm) != 0) {
 		ERROR("Unable to get terminal settings (%d: %s).", __LINE__, strerror(errno));
+		free(buf);
 		return (NULL);
 	}
 
@@ -185,6 +187,7 @@ static char* callback_sshauth_password_default (const char* username,
 	tcflush(fileno(tty), TCIFLUSH);
 	if (tcsetattr(fileno(tty), TCSANOW, &newterm) != 0) {
 		ERROR("Unable to change terminal settings for hiding password (%d: %s).", __LINE__, strerror(errno));
+		free(buf);
 		return (NULL);
 	}
 
@@ -332,11 +335,13 @@ static char* callback_sshauth_publickey_default (const char*  UNUSED(username),
 
 	if ((tty = fopen("/dev/tty", "r+")) == NULL) {
 		ERROR("Unable to open the current terminal (%s:%d - %s).", __FILE__, __LINE__, strerror(errno));
+		free(buf);
 		return (NULL);
 	}
 
 	if (tcgetattr(fileno(tty), &oldterm) != 0) {
 		ERROR("Unable to get terminal settings (%d: %s).", __LINE__, strerror(errno));
+		free(buf);
 		return (NULL);
 	}
 
@@ -350,6 +355,7 @@ static char* callback_sshauth_publickey_default (const char*  UNUSED(username),
 	tcflush(fileno(tty), TCIFLUSH);
 	if (tcsetattr(fileno(tty), TCSANOW, &newterm) != 0) {
 		ERROR("Unable to change terminal settings for hiding password (%d: %s).", __LINE__, strerror(errno));
+		free(buf);
 		return (NULL);
 	}
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -518,6 +518,7 @@ struct nc_session *nc_session_connect_libssh_channel(struct nc_session *session)
 
 	if (pthread_mutexattr_init(&mattr) != 0) {
 		ERROR("Memory allocation failed (%s:%d).", __FILE__, __LINE__);
+		free(retval);
 		return (NULL);
 	}
 	pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_RECURSIVE);
@@ -527,6 +528,7 @@ struct nc_session *nc_session_connect_libssh_channel(struct nc_session *session)
 			(r = pthread_mutex_init(&(retval->mut_session), &mattr)) != 0) {
 		ERROR("Mutex initialization failed (%s).", strerror(r));
 		pthread_mutexattr_destroy(&mattr);
+		free(retval);
 		return (NULL);
 	}
 	pthread_mutexattr_destroy(&mattr);

--- a/src/transport.c
+++ b/src/transport.c
@@ -875,6 +875,7 @@ struct nc_session* _nc_session_accept(const struct nc_cpblts* capabilities, cons
 
 	if (pthread_mutexattr_init(&mattr) != 0) {
 		ERROR("Memory allocation failed (%s:%d).", __FILE__, __LINE__);
+		free(retval);
 		return (NULL);
 	}
 	retval->mut_channel = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
@@ -886,6 +887,7 @@ struct nc_session* _nc_session_accept(const struct nc_cpblts* capabilities, cons
 			(r = pthread_mutex_init(&(retval->mut_session), &mattr)) != 0) {
 		ERROR("Mutex initialization failed (%s).", strerror(r));
 		pthread_mutexattr_destroy(&mattr);
+		free(retval);
 		return (NULL);
 	}
 	pthread_mutexattr_destroy(&mattr);


### PR DESCRIPTION
This patch attempts to fix minor memory leaks in the following functions, found by cppcheck:

src/callbacks.c: callback_sshauth_{password,publickey}_default
src/ssh.c: nc_session_connect_libssh_channel
src/transport.c: _nc_session_accept

Although I have inspected the changes visually, built with change and confirmed that I did not see any compiler warnings related to the changes, I have not attempted to run the code and may not be able to respond to feedback about this pull request for the rest of the day, but I will attempt to respond if anyone has any questions.  Thanks for considering this submission.