### PR TITLE
Address a few more cppcheck complaints

### DIFF
--- a/src/datastore.c
+++ b/src/datastore.c
@@ -1695,6 +1695,7 @@ static char* compare_schemas(struct data_model* model, char* name, char* version
 			/* perhaps starts with "<?xml"? */
 			if (fread(retval, 1, 5, file) < 5) {
 				ERROR("%s: failed to read \"%s\" (%s).", __func__, model->path, strerror(errno));
+				free(retval);
 				fclose(file);
 				return (ERROR_POINTER);
 			}
@@ -1724,6 +1725,7 @@ static char* compare_schemas(struct data_model* model, char* name, char* version
 			/* read the rest */
 			if (fread(retval + start, 1, size, file) < (unsigned)size) {
 				ERROR("%s: failed to read \"%s\" (%s).", __func__, model->path, strerror(errno));
+				free(retval);
 				fclose(file);
 				return (ERROR_POINTER);
 			}
@@ -3433,6 +3435,7 @@ API int ncds_add_augment_transapi_static(const char* model_path, const struct tr
 		/* allocate transapi structure */
 		if ((model->transapi = malloc(sizeof(struct transapi_internal))) == NULL) {
 			ERROR("Memory allocation failed - %s (%s:%d).", strerror (errno), __FILE__, __LINE__);
+			free(tapi_item);
 			ncds_ds_model_free(model);
 			return (EXIT_FAILURE);
 		}

--- a/src/datastore/edit_config.c
+++ b/src/datastore/edit_config.c
@@ -142,9 +142,7 @@ static NC_EDIT_OP_TYPE get_operation(xmlNodePtr node, NC_EDIT_DEFOP_TYPE defop, 
 			op = NC_EDIT_OP_REMOVE;
 		} else {
 			if (error != NULL) {
-				if (error != NULL) {
-					*error = nc_err_new(NC_ERR_BAD_ATTR);
-				}
+				*error = nc_err_new(NC_ERR_BAD_ATTR);
 				nc_err_set(*error, NC_ERR_PARAM_INFO_BADATTR, NC_EDIT_ATTR_OP);
 			}
 			op = NC_EDIT_OP_ERROR;
@@ -714,9 +712,6 @@ static xmlXPathObjectPtr get_operation_elements(NC_EDIT_OP_TYPE op, xmlDocPtr ed
 	/* create xpath evaluation context */
 	edit_ctxt = xmlXPathNewContext(edit);
 	if (edit_ctxt == NULL) {
-		if (edit_ctxt != NULL) {
-			xmlXPathFreeContext(edit_ctxt);
-		}
 		ERROR("Creating the XPath evaluation context failed (%s:%d).", __FILE__, __LINE__);
 		return (NULL);
 	}

--- a/src/internal.c
+++ b/src/internal.c
@@ -259,7 +259,7 @@ static int nc_apps_check(const char* comm, struct nc_apps* apps) {
 		if (readcount < 0) {
 			continue;
 		}
-		if (runcomm[readcount-1] == '\n') {
+		if (readcount > 0 && runcomm[readcount-1] == '\n') {
 			runcomm[readcount-1] = '\0';
 		} else {
 			runcomm[readcount] = '\0';

--- a/src/session.c
+++ b/src/session.c
@@ -303,11 +303,15 @@ API int nc_session_monitor(struct nc_session* session)
 #define UNKN_HOST "UNKNOWN"
 #define UNKN_HOST_SIZE 8
 
+	if (session == NULL) {
+		return (EXIT_FAILURE);
+	}
+
 	if (session->monitored) {
 		return (EXIT_SUCCESS);
 	}
 
-	if (session == NULL || session_list == NULL) {
+	if (session_list == NULL) {
 		return (EXIT_FAILURE);
 	}
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -1181,7 +1181,7 @@ API int nc_callhome_listen(unsigned int port)
 		port = NC_REVERSE_PORT;
 	}
 
-	if (snprintf(port_s, SHORT_INT_LENGTH, "%d", port) < 0) {
+	if (snprintf(port_s, SHORT_INT_LENGTH, "%u", port) < 0) {
 		/* converting short int to the string failed */
 		ERROR("Unable to convert the port number to a string.");
 		return (EXIT_FAILURE);


### PR DESCRIPTION
Thank you for merging my previous pull request so quickly, Michal.  Here are a few more attempted clean-ups of complaints from cppcheck:

src/datastore.c: minor memory leaks in error branches
src/internal.c: potential memory corruption (one byte, unlikely)
src/transport.c: "%d" should be "%u" in a format string
src/session.c: possible null pointer dereference
src/datastore/edit_config.c: remove two redundant "if" tests.

As with my previous pull request, although I have inspected the changes visually, built with the changes and confirmed that I did not see any compiler warnings related to the changes, I have not attempted to run the code, but I will be happy to respond to any questions.

Thanks for considering this patch submission.